### PR TITLE
Call onSelect from setSelect

### DIFF
--- a/js/jquery.Jcrop.js
+++ b/js/jquery.Jcrop.js
@@ -1300,8 +1300,8 @@
     //}}}
     function setSelect(rect) //{{{
     {
-      setSelectRaw([
-      parseInt(rect[0], 10) / xscale, parseInt(rect[1], 10) / yscale, parseInt(rect[2], 10) / xscale, parseInt(rect[3], 10) / yscale]);
+      setSelectRaw([parseInt(rect[0], 10) / xscale, parseInt(rect[1], 10) / yscale, parseInt(rect[2], 10) / xscale, parseInt(rect[3], 10) / yscale]);
+      options.onSelect.call(api, unscale(Coords.getFixed()));
     }
     //}}}
     function setSelectRaw(l) //{{{


### PR DESCRIPTION
Prevents crop error when initialSelection is used and user doesn't change the default selection
