### PR TITLE
Image position issue in Firefox

### DIFF
--- a/js/jquery.Jcrop.js
+++ b/js/jquery.Jcrop.js
@@ -285,7 +285,9 @@
       border: 'none',
       margin: 0,
       padding: 0,
-      position: 'absolute'
+      position: 'absolute',
+      top: 0,
+      left: 0
     };
 
     var $origimg = $(obj);


### PR DESCRIPTION
In Firefox (in certain situations) the image would not be properly positioned at top: 0 and left: 0.  Added code to force it so that it works no matter what.
