### PR TITLE
Display the image if display:none is set on the original

### DIFF
--- a/js/jquery.Jcrop.js
+++ b/js/jquery.Jcrop.js
@@ -286,13 +286,12 @@
       margin: 0,
       padding: 0,
       position: 'absolute',
-      display: 'block',
       top: 0,
       left: 0
     };
 
     var $origimg = $(obj);
-    var $img = $origimg.clone().removeAttr('id').css(img_css);
+    var $img = $origimg.clone().removeAttr('id').css(img_css).show();
 
     $img.width($origimg.width());
     $img.height($origimg.height());


### PR DESCRIPTION
Display the image if the cropper is created on top of an image with display: none.
This fix wrong position at first drag.
