### PR TITLE
Added getOptions method to API (setOptions exists, but no getOptions?)

### DIFF
--- a/js/jquery.Jcrop.js
+++ b/js/jquery.Jcrop.js
@@ -1543,6 +1543,9 @@
       setImage: setImage,
       animateTo: animateTo,
       setSelect: setSelect,
+      getOptions: function () { 
+        return options; 
+      },
       setOptions: setOptionsNew,
       tellSelect: tellSelect,
       tellScaled: tellScaled,


### PR DESCRIPTION
This is needed for my jquery.jcrop.preview plugin, as access to the aspectRatio value is required to solve a rounding bug.
