### PR TITLE
This is a small fix for using with Bootstrap from Twitter

### DIFF
--- a/css/jquery.Jcrop.css
+++ b/css/jquery.Jcrop.css
@@ -82,3 +82,8 @@
 	border-radius:3px;
 }
 
+/* Fix for using with Bootstrap, from Twitter */
+div.jcrop-holder img, img#preview
+{
+  max-width: none;
+}


### PR DESCRIPTION
I've lost about 5 hours to find the problem. When this patch is not applied, you get this: ![Bug](http://cl.ly/FfC6/%D0%A1%D0%BD%D0%B8%D0%BC%D0%BE%D0%BA%20%D1%8D%D0%BA%D1%80%D0%B0%D0%BD%D0%B0%202012-04-07%20%D0%B2%2022.20.34.png).
This patch fixes it.
