### PR TITLE
Improve precision with fixed aspect ratio

### DIFF
--- a/js/jquery.Jcrop.js
+++ b/js/jquery.Jcrop.js
@@ -37,7 +37,7 @@
 
     // Internal Methods {{{
     function px(n) {
-      return parseInt(n, 10) + 'px';
+      return n + 'px';
     }
     function cssClass(cl) {
       return options.baseClass + '-' + cl;
@@ -201,12 +201,12 @@
     function unscale(c) //{{{
     {
       return {
-        x: parseInt(c.x * xscale, 10),
-        y: parseInt(c.y * yscale, 10),
-        x2: parseInt(c.x2 * xscale, 10),
-        y2: parseInt(c.y2 * yscale, 10),
-        w: parseInt(c.w * xscale, 10),
-        h: parseInt(c.h * yscale, 10)
+        x: c.x * xscale,
+        y: c.y * yscale,
+        x2: c.x2 * xscale,
+        y2: c.y2 * yscale,
+        w: c.w * xscale,
+        h: c.h * yscale
       };
     }
     //}}}
@@ -653,7 +653,7 @@
           ya = y2;
           yb = y1;
         }
-        return [Math.round(xa), Math.round(ya), Math.round(xb), Math.round(yb)];
+        return [xa, ya, xb, yb];
       }
       //}}}
       function getRect() //{{{
@@ -1316,10 +1316,10 @@
     //}}}
     function animateTo(a, callback) //{{{
     {
-      var x1 = parseInt(a[0], 10) / xscale,
-          y1 = parseInt(a[1], 10) / yscale,
-          x2 = parseInt(a[2], 10) / xscale,
-          y2 = parseInt(a[3], 10) / yscale;
+      var x1 = a[0] / xscale,
+          y1 = a[1] / yscale,
+          x2 = a[2] / xscale,
+          y2 = a[3] / yscale;
 
       if (animating) {
         return;
@@ -1376,7 +1376,7 @@
     //}}}
     function setSelect(rect) //{{{
     {
-      setSelectRaw([parseInt(rect[0], 10) / xscale, parseInt(rect[1], 10) / yscale, parseInt(rect[2], 10) / xscale, parseInt(rect[3], 10) / yscale]);
+      setSelectRaw([rect[0] / xscale, rect[1] / yscale, rect[2] / xscale, rect[3] / yscale]);
       options.onSelect.call(api, unscale(Coords.getFixed()));
       Selection.enableHandles();
     }


### PR DESCRIPTION
I have removed calls of "parseInt(x, 10)" and "Math.round()" to improve the precision when a fixed aspect ratio is set. This does not seem to have any negative consequences because CSS can handle not only integers but also floats.
