### PR TITLE
add allowReselect option

### DIFF
--- a/js/jquery.Jcrop.js
+++ b/js/jquery.Jcrop.js
@@ -165,7 +165,7 @@
         if (options.disabled) {
           return false;
         }
-        if ((ord === 'move') && !options.allowMove && !options.allowReselect) {
+        if ((ord === 'move') && !(options.allowMove || (options.allowSelect && options.allowReselect))) {
           return false;
         }
 
@@ -174,7 +174,7 @@
         docOffset = getPos($img);
         btndown = true;
 
-        if (ord === 'move' && !options.allowMove && options.allowReselect) {
+        if (ord === 'move' && !options.allowMove && options.allowSelect && options.allowReselect) {
           Selection.disableHandles();
           Tracker.setCursor('crosshair');
           var pos = mouseAbs(e);


### PR DESCRIPTION
- ables to drag within tracker and start a new selection
- works only when 'allowMove' is false and 'allowSelect' is true

---

I was looking for a way to start a new selection when dragging from inside the tracker. It's a case when the user focuses on making the correct selection from the whole image, regardless of the previous one.

Of course this would only be possible when `allowMove` is false, because the behavior of moving the tracker  collides with it, and also when `allowSelect` is set to true.

This might be a minor case, but I thought it might come handy for people like me.
