### PR TITLE
Add options for minimum and maximum aspect ratio 

### DIFF
--- a/js/jquery.Jcrop.js
+++ b/js/jquery.Jcrop.js
@@ -95,19 +95,36 @@
     function dragmodeHandler(mode, f) //{{{
     {
       return function (pos) {
-        switch (mode) {
-        case 'e':
-          pos[1] = f.y2;
-          break;
-        case 'w':
-          pos[1] = f.y2;
-          break;
-        case 'n':
-          pos[0] = f.x2;
-          break;
-        case 's':
-          pos[0] = f.x2;
-          break;
+        if (!options.minAspectRatio || !options.maxAspectRatio) {
+          switch (mode) {
+          case 'e':
+            pos[1] = f.y2;
+            break;
+          case 'w':
+            pos[1] = f.y2;
+            break;
+          case 'n':
+            pos[0] = f.x2;
+            break;
+          case 's':
+            pos[0] = f.x2;
+            break;
+          }
+        } else {
+          switch (mode) {
+          case 'e':
+            pos[1] = f.y + 1;
+            break;
+          case 'w':
+            pos[1] = f.y + 1;
+            break;
+          case 'n':
+            pos[0] = f.x + 1;
+            break;
+          case 's':
+            pos[0] = f.x + 1;
+            break;
+          }
         }
         Coords.setCurrent(pos);
         Selection.update();


### PR DESCRIPTION
This is a backwards compatible change that allows developers to specify limits on the aspect ratio of the crop. For example, a developer could specify a minimum aspect ratio of 1.0 to allow wide crops, but disallow any crop that is taller than a square.

Passing in the option aspectRatio to keep the ratio completely fixed is still supported.
