### PR TITLE
Off-by-one rounding issue causes $img2 to shift by 1px when manipulating crop box

### DIFF
--- a/js/jquery.Jcrop.js
+++ b/js/jquery.Jcrop.js
@@ -933,9 +933,16 @@
       function moveto(x, y) //{{{
       {
         if (!options.shade) {
+          // rounding 0.5 results in 1, -0.5 to 0. the
+          // px method rounds the negative value, so
+          // the box will jump around if y or x is a
+          // non whole-number multiple of 0.5
+          y = Math.round(Math.abs(y));
+          x = Math.round(Math.abs(x));
+
           $img2.css({
-            top: px(-y),
-            left: px(-x)
+            top: (-y).toString() + "px",
+            left: (-x).toString() + "px"
           });
         }
         $sel.css({


### PR DESCRIPTION
When manipulating cropbox, moveTo method is passed x and y values from Coords.getFixed. These numbers are quite oftentimes decimal values. When the decimal value is a non-integer multiple of 0.5 (1.5, 2.5, 99.5, 102.5), the rounding resulting in the left and top offsets is off-by-one. This is because the number is first made negative and THEN the rounding occurs, e.g.:

Math.round(0.5); // === 1
Math.round(-0.5); // === 0;

The solution might be to patch the "px" method - but it's used in so many places that I was unwilling to simply cowboy a patch and hope for the best.

![Jcrop-off-by-one](https://f.cloud.github.com/assets/884507/58429/7b10770c-5b70-11e2-813e-4e4c30b7c6fe.png)
