### PR TITLE
Set maxWidth and maxHeight to 'none'.

### DIFF
--- a/js/jquery.Jcrop.js
+++ b/js/jquery.Jcrop.js
@@ -290,7 +290,9 @@
       padding: 0,
       position: 'absolute',
       top: 0,
-      left: 0
+      left: 0,
+      maxWidth: 'none',
+      maxHeight: 'none'
     };
 
     var $origimg = $(obj),


### PR DESCRIPTION
Some reset frameworks [set maxWidth img style](https://github.com/twitter/bootstrap/blob/master/less/reset.less#L81). maxWidth and maxHeight breaks jCrop actual image size calculation.
