### PR TITLE
Improving a function `presize` using new parameter `photoRealSize`

### DIFF
--- a/js/jquery.Jcrop.js
+++ b/js/jquery.Jcrop.js
@@ -187,17 +187,25 @@
     function presize($obj, w, h) //{{{
     {
       var nw = $obj.width(),
-          nh = $obj.height();
-      if ((nw > w) && w > 0) {
+          nh = $obj.height(),
+          rw = nw,
+          rh = nh;
+
+      if (options.photoRealSize) {
+        rw = options.photoRealSize[0];
+        rh = options.photoRealSize[1];
+      }
+
+      if ((rw > w) && w > 0) {
         nw = w;
-        nh = (w / $obj.width()) * $obj.height();
+        nh = (w / rw) * rh;
       }
-      if ((nh > h) && h > 0) {
+      if ((rh > h) && h > 0) {
         nh = h;
-        nw = (h / $obj.height()) * $obj.width();
+        nw = (h / rh) * rw;
       }
-      xscale = $obj.width() / nw;
-      yscale = $obj.height() / nh;
+      xscale = rw / nw;
+      yscale = rh / nh;
       $obj.width(nw).height(nh);
     }
     //}}}


### PR DESCRIPTION
Hello.

In our current project we faced with the problem: our cropped image had css property `width` and the function `presize` could not properly count a real width of the image. Therefore, scale parameters also was incorrect (in our case they equals 1 instead of a value about 4).

I added a new parameter `photoRealSize` for improving the `presize` function.

Look the commit. For example, we used this parameter like this:

``` coffeescript
@.initCrop = ->
  img = new Image()
  img.onload = ->
    w = @width
    h = @height

    $("#img").Jcrop {
      boxWidth : 600
      aspectRatio: 4.0/3
      bgOpacity: 0.3
      photoRealSize: [w, h]
      minSize: [200, 150]
      addClass: 'jcrop-dark'
      onSelect: setCoords
    }, ->
      setBounds(@)
      return

    return

  img.src = $("#img").attr("src")
  return
```

If this parameter will not be specified, we will have old behavior of the function `presize`.

Thank you for your job!
