### PR TITLE
Added class to the tracker for the viewport

### DIFF
--- a/js/jquery.Jcrop.js
+++ b/js/jquery.Jcrop.js
@@ -1089,7 +1089,7 @@
         cursor: 'move',
         position: 'absolute',
         zIndex: 360
-      });
+      }).addClass("jcrop-viewport");
 
       if (Touch.support) {
         $track.bind('touchstart.jcrop', Touch.createDragger('move'));


### PR DESCRIPTION
This commit will include an additional class on the tracker that shows when a user is attempting to crop. This allows for someone to skin the crop viewport to add an overlay if desired. The class is named "jcrop-viewport" to allow for specificity within CSS to target it directly.
