### PR TITLE
Set selection to [0, 0, 0, 0] on release()

### DIFF
--- a/js/jquery.Jcrop.js
+++ b/js/jquery.Jcrop.js
@@ -1019,6 +1019,8 @@
       {
         disableHandles();
         $sel.hide();
+        
+        setSelectRaw([0, 0, 0, 0]);
 
         if (options.shade) Shade.opacity(1);
           else setBgOpacity(1);


### PR DESCRIPTION
I recently found myself needing to compare different "saved" selections with the one currently being displayed. When the selection was "released" it would still match the last one used, because release() doesn't currently change the selection (it just hides it). This prevents scripts from using tellScale() to accurately determine what is selected. Calling tellScale() on a "released" jcrop will still return the last selection before release() was called.

This commit changes the selection to [0, 0, 0, 0], in addition to visually hiding the selection. It is then trivial to compare the array to others.

Another option I considered was to call setSelection() right after release, but this would trigger another event, which was undesirable. I noticed there is a pull request to optionally silence the events with these calls, but it would still require 2 API calls and I think this is cleaner, without introducing a conceptual change.

I hope you find this useful and please let me know if you have any questions or suggestions.
