### PR TITLE
Use naturalWidth and naturalHeight of image in `presize()` to ensure correct image dimensions

### DIFF
--- a/js/jquery.Jcrop.js
+++ b/js/jquery.Jcrop.js
@@ -208,12 +208,12 @@
     function unscale(c) //{{{
     {
       return {
-        x: c.x * xscale,
-        y: c.y * yscale,
-        x2: c.x2 * xscale,
-        y2: c.y2 * yscale,
-        w: c.w * xscale,
-        h: c.h * yscale
+        x: Math.floor(c.x * xscale),
+        y: Math.floor(c.y * yscale),
+        x2: Math.floor(c.x2 * xscale),
+        y2: Math.floor(c.y2 * yscale),
+        w: Math.floor(c.w * xscale),
+        h: Math.floor(c.h * yscale)
       };
     }
     //}}}


### PR DESCRIPTION
`presize()` was initializing with the wrong dimensions when using an extremely large image (1800x5765).  

So,  `$obj.width()` becomes `$obj.naturalWidth()`, and `$obj.height()` becomes `$obj.naturalHeight()`.

`naturalWidth` is available in modern browsers, but I've  included the jQuery polyfill for `naturalWidth` directly in the Jcrop source... there might be a better way to include that.

Finally, thanks for creating Jcrop, it's quite handy! If you need help writing some unit tests for this so future pull-requests can more easily be validated then let me know.
