### PR TITLE
Fix for Heroku that has issues with http submodules on Github

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "build/less/bs"]
 	path = build/less/bs
-	url = http://github.com/twbs/bootstrap.git
+	url = https://github.com/twbs/bootstrap.git


### PR DESCRIPTION
Heroku has issues following redirects that Github sends when a submodule is using http:// instead of https://
This simple changes the submodule URL to use HTTPS.
