### PR TITLE
Do not disable scroll on jcrop-tracker

### DIFF
--- a/js/jquery.Jcrop.js
+++ b/js/jquery.Jcrop.js
@@ -228,10 +228,10 @@
     function newSelection(e) //{{{
     {
       if (options.disabled) {
-        return false;
+        return;
       }
       if (!options.allowSelect) {
-        return false;
+        return;
       }
       btndown = true;
       docOffset = getPos($img);


### PR DESCRIPTION
Users can't scroll page on touch devices, when they start scroll from jcrop-tracker element and `options.allowSelect == false`. This happens because newSelection returns `false` and jQuery treat this as `preventDefault()`.
