### PR TITLE
Scale minSize/maxSize properly.

### DIFF
--- a/js/jquery.Jcrop.js
+++ b/js/jquery.Jcrop.js
@@ -655,11 +655,11 @@
             ysize = y2 - y1,
             delta;
 
-        if (xlimit && (Math.abs(xsize) > xlimit)) {
-          x2 = (xsize > 0) ? (x1 + xlimit) : (x1 - xlimit);
+        if (xlimit && (Math.abs(xsize) > xlimit / xscale)) {
+          x2 = (xsize > 0) ? (x1 + xlimit / xscale) : (x1 - xlimit / xscale);
         }
-        if (ylimit && (Math.abs(ysize) > ylimit)) {
-          y2 = (ysize > 0) ? (y1 + ylimit) : (y1 - ylimit);
+        if (ylimit && (Math.abs(ysize) > ylimit / yscale)) {
+          y2 = (ysize > 0) ? (y1 + ylimit / yscale) : (y1 - ylimit / yscale);
         }
 
         if (ymin / yscale && (Math.abs(ysize) < ymin / yscale)) {


### PR DESCRIPTION
This fixes #40 issue with minSize/maxSize scaling when using boxWidth/boxHeight or trueSize.
