### PR TITLE
Fixes #71 Crash in IE10 when running in IE7 mode

### DIFF
--- a/js/jquery.Jcrop.js
+++ b/js/jquery.Jcrop.js
@@ -1235,7 +1235,7 @@
       {
         if (options.keySupport) {
           $keymgr.show();
-          $keymgr.focus();
+          $keymgr.triggerHandler( "focus" );
         }
       }
       //}}}


### PR DESCRIPTION
This was caused by calling jQuery .focus() on a hidden element. It is a known Internet Explorer error as documented in jQuery's documentation here: https://api.jquery.com/focus/
