### PR TITLE
Disabling new selection and dragging using the right mouse button.

### DIFF
--- a/js/jquery.Jcrop.js
+++ b/js/jquery.Jcrop.js
@@ -165,7 +165,7 @@
     function createDragger(ord) //{{{
     {
       return function (e) {
-        if (options.disabled) {
+        if (options.disabled || e.which == 3) {
           return false;
         }
         if ((ord === 'move') && !options.allowMove) {
@@ -230,7 +230,7 @@
       if (options.disabled) {
         return;
       }
-      if (!options.allowSelect) {
+      if (!options.allowSelect || e.which == 3) {
         return;
       }
       btndown = true;


### PR DESCRIPTION
Hello tapmodo!

When I click the second mouse button (the right one on my mouse), I do not expect new selections or dragging to occur.

This selection checks which mouse button you use in mousedown handlers.

/Anders