### PR TITLE
[2.0] Thumbnailer component: container option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 demos/test*
 node_modules
+.idea

--- a/demos/thumbnail.html
+++ b/demos/thumbnail.html
@@ -123,7 +123,11 @@ such as a border or a box shadow can be added if desired.</p>
 
 <h3>Additional Features</h3>
 
-<ul><li>Can be locked to an individual Selection object.</li><li>Can be resized using <code>resize(w,h)</code> method.</li></ul>
+<ul>
+  <li>Can be locked to an individual Selection object.</li>
+  <li>Can be resized using <code>resize(w,h)</code> method.</li>
+  <li>Can be inserted in selected container by providing element in <code>container</code> option.</li>
+</ul>
             <div class="tapmodo-footer"><a href="http://tapmodo.com" class="tapmodo-logo segment">tapmodo.com</a>
               <div class="segment"><b>&copy; 2008-2013 Tapmodo Interactive LLC</b>
                 <div>Jcrop is free software released under <a href="../MIT-LICENSE.txt">MIT License</a></div>

--- a/src/component/Thumbnailer.js
+++ b/src/component/Thumbnailer.js
@@ -7,6 +7,7 @@
       // If this value is set, the preview will only track that Selection
       selection: null,
 
+      container: null, // defaults to jCrop container
       fading: true,
       fadeDelay: 1000,
       fadeDuration: 1000,
@@ -24,6 +25,7 @@
       init: function(core,options){
         var t = this;
         this.core = core;
+        Thumbnailer.defaults.container = this.core.container;
         $.extend(this,Thumbnailer.defaults,options);
         t.initEvents();
         t.refresh();
@@ -56,7 +58,7 @@
         this.element = $('<div />').addClass('jcrop-thumb')
           .width(this.width).height(this.height)
           .append(this.preview)
-          .appendTo(this.core.container);
+          .appendTo(this.container);
       },
       resize: function(w,h){
         this.width = w;


### PR DESCRIPTION
Allows you to specify a container of thumb generated by `Thumbnailer` component by providing `container` option.

Example:
```javascript
this.initComponent('Thumbnailer', { 
    width: 250, 
    height: 250, 
    container: $('#preview250') 
});
```