### PR TITLE
we should not mention a specific version of engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "engines": {
-    "node": "8.9.4",
-    "npm": "5.8.0"
+    "node": ">=8.9.4",
+    "npm": ">=5.8.0"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
because of these, it is failing in latest version
ps1: it may not needed to use those engine requirements at all
ps2: even if we need them, better to have lower versions possible with which package works.