### PR TITLE
Update guide to use correct method

### DIFF
--- a/docs/guide/instance.md
+++ b/docs/guide/instance.md
@@ -143,7 +143,7 @@ Add a new cropping widget using a [`Rect`](/objects/rect.html) object.
 
 ```js{2}
 const rect = Jcrop.Rect.fromPoints([100,100],[200,200]);
-jcrop.newCropper(rect,{ aspectRatio: rect.aspect });
+jcrop.newWidget(rect,{ aspectRatio: rect.aspect });
 ```
 
 ### CSS class management


### PR DESCRIPTION
Currently the guide shows an example that calls `newCropper()` on a Jcrop instance. This does not actually work because, as far as I can tell, this method does not exist. Additionally, the header above already shows the working method, `newWidget()`. Hopefully this change will save someone else some time and prevent them from banging their head against a wall for no reason 😄.